### PR TITLE
Correct translation issue

### DIFF
--- a/src/FancyTreeviewClass.php
+++ b/src/FancyTreeviewClass.php
@@ -549,7 +549,7 @@ class FancyTreeviewClass extends FancyTreeviewModule {
 		if ($count > 1) {
 			// we assume no one married more then ten times.
 			$wordcount = array(
-				I18N::translate('first'),
+				I18N::translateContext('Show the [first/last] [N] parts of a place name.','first'),
 				I18N::translate('second'),
 				I18N::translate('third'),
 				I18N::translate('fourth'),


### PR DESCRIPTION
Using TranslateContext iso Translate is better for French. That way "première" is used and not "début".
I checked Dutch and English as well and it is also OK according to me.
